### PR TITLE
Fix/cannot scroll in planning

### DIFF
--- a/app/[id]/(tabs)/planning/_layout.tsx
+++ b/app/[id]/(tabs)/planning/_layout.tsx
@@ -72,10 +72,7 @@ export default function PlanningLayout() {
             }}>
                 <Stack.Screen name="index" />
                 <Stack.Screen name="calendar" />
-                <Stack.Screen name="day" options={{
-                    presentation: "modal",
-
-                }} />
+                <Stack.Screen name="day" />
             </Stack>
         </View>
 

--- a/app/[id]/(tabs)/planning/calendar.tsx
+++ b/app/[id]/(tabs)/planning/calendar.tsx
@@ -102,7 +102,7 @@ export default function TripCalendar() {
     };
 
     return (
-        <Animated.View style={styles.container}>
+        <Animated.ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
             <Calendar
                 current={currentDate}
                 onMonthChange={(date) => setCurrentDate(date.dateString)}
@@ -141,7 +141,7 @@ export default function TripCalendar() {
 
             />
             {selectedDay && (
-                <Animated.ScrollView
+                <Animated.View
                     entering={SlideInDown.duration(300)}
                     exiting={SlideOutDown.duration(200)}
                 >
@@ -205,8 +205,8 @@ export default function TripCalendar() {
                             })}
                         />
                     </View>
-                </Animated.ScrollView>
+                </Animated.View>
             )}
-        </Animated.View>
+        </Animated.ScrollView>
     )
 }

--- a/app/[id]/(tabs)/planning/calendar.tsx
+++ b/app/[id]/(tabs)/planning/calendar.tsx
@@ -195,6 +195,7 @@ export default function TripCalendar() {
                         <Button variant="contained"
                             title="Ajouter"
                             size="small"
+                            className="my-2"
                             onPress={() => router.push({
                                 pathname: "/[id]/events/new",
                                 params: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar navigation by enabling smooth scrolling across the full planning page.
  * Removed nested scrolling from day details for a more consistent browsing experience.
  * Updated day views to open as standard pages instead of modal windows.

* **Style**
  * Added spacing around the “Ajouter” button for improved layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->