### PR TITLE
fix: utilisation des dates du voyage pour les nouvelles activités

### DIFF
--- a/app/[id]/events/new/_layout.tsx
+++ b/app/[id]/events/new/_layout.tsx
@@ -1,44 +1,48 @@
 import { Button } from "@/components/ui/Button";
 import { Chip } from "@/components/ui/Chip";
 import { IconSymbol } from "@/components/ui/IconSymbol";
+import { TripContext } from "@/context/TripContext"; 
 import { usePostEvent } from "@/hooks/api/useEvents";
 import useColors from "@/hooks/styles/useColors";
 import { Event } from "@/types/models";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { View } from "react-native";
 
-
-const firstParam = (value: string | string[] | undefined) : string =>
-    Array.isArray(value) ? value?.[0] : value || "";
-
-
-
+// 1️⃣ Fix Lapin : Typage propre pour accepter 'undefined' sans faire planter TypeScript
+const firstParam = (value: string | string[] | undefined): string | undefined =>
+    Array.isArray(value) ? value[0] : value;
 
 export default function NewEventLayout() {
+    // 2️⃣ Fix frecapG7 : On retire 'id' d'ici, il est devenu inutile
+    const { startDate, endDate } = useLocalSearchParams();
+    
+    const { trip } = useContext(TripContext); 
 
-    const { id, startDate, endDate } = useLocalSearchParams();
     const methods = useForm<Omit<Event, "_id">>({
         defaultValues: {
             name: "",
             type: "",
+            // 3️⃣ Fix frecapG7 : Retour en arrière. On ne force plus la date ici pour éviter
+            // que tous les événements soient créés le 1er jour du séjour.
             ...(startDate && {startDate: firstParam(startDate)}),
             ...(endDate && {endDate: firstParam(endDate)})
         }
     });
 
     const router = useRouter();
-
     const {text} = useColors();
-    const postEvent = usePostEvent(id);
-
+    
+    // ✨ Fix frecapG7 / Lapin : On manipule directement l'ID depuis l'objet trip !
+    const postEvent = usePostEvent(trip?._id);
 
     const onSubmit = async (data: Omit<Event, '_id'>) => {
         const newEvent = await postEvent.mutateAsync(data);
         router.navigate({
             pathname: "/[id]/events/[eventId]",
             params: {
-                id: String(id),
+                id: trip?._id, // On utilise l'ID sécurisé du trip
                 eventId: newEvent._id
             }
         });
@@ -52,7 +56,7 @@ export default function NewEventLayout() {
                 <Button onPress={() => router.dismissTo({
                     pathname: "/[id]/(tabs)/planning",
                     params: {
-                        id: String(id)
+                        id: trip?._id // On utilise l'ID sécurisé du trip
                     }
                 })}>
                     <IconSymbol name="xmark" color={text} size={24} />
@@ -94,13 +98,8 @@ export default function NewEventLayout() {
                         ),
                         title: "",
                     }}
-
                 />
             </Stack>
         </FormProvider>
     )
-
-
-
-
 }

--- a/components/events/EventInfoForm.tsx
+++ b/components/events/EventInfoForm.tsx
@@ -5,13 +5,15 @@ import { Text, View } from "react-native"
 import { FormDateTimePickerV2 } from "../form/FormDateTimePickerV2"
 import { FormText } from "../form/FormText"
 import { FormTextArea } from "../form/FormTextArea"
-
-
+// 🚨 Ajout des imports pour récupérer le Trip
+import { useContext } from "react"
+import { TripContext } from "@/context/TripContext"
 
 export const EventInfoForm = ({ control }: { control: Control<Event> }) => {
 
     const { text } = useColors();
-
+    // 🚨 On récupère le voyage depuis la mémoire
+    const { trip } = useContext(TripContext);
 
     const startDate = useWatch({
         control,
@@ -32,7 +34,6 @@ export const EventInfoForm = ({ control }: { control: Control<Event> }) => {
                         required: true,
                         maxLength: 55
                     }} />
-
             </View>
 
             <View className="">
@@ -61,11 +62,11 @@ export const EventInfoForm = ({ control }: { control: Control<Event> }) => {
                         rules={{
                             required: false
                         }}
+                        // ✨ On passe la fameuse prop demandée par ton dev !
+                        initialDate={trip?.startDate}
                     />
                 </View>
             </View>
-
-
         </View>
     )
 }

--- a/components/form/FormDateTimePickerV2.tsx
+++ b/components/form/FormDateTimePickerV2.tsx
@@ -8,8 +8,6 @@ import { Pressable, Text, View } from "react-native";
 import { Calendar, CalendarUtils } from "react-native-calendars";
 import Animated, { FadeIn, FadeOut, StretchInY, StretchOutY } from "react-native-reanimated";
 
-
-
 const hoursItems = Array.from({ length: 24 }).map((_, index) => ({
     value: index,
     label: index < 10 ? "0" + index : index
@@ -35,11 +33,9 @@ const WheelTimePicker = ({ value, onChangeHour, onChangeMinute }: { value?: Date
                 }}
                 itemTextStyle={{
                     color: colors.text,
-                    // backgroundColor:colors.neutral
                 }}
                 overlayItemStyle={{
                     backgroundColor: colors.neutral
-                    // marHorizontal: 10
                 }}
             />
             <WheelPicker
@@ -53,23 +49,21 @@ const WheelTimePicker = ({ value, onChangeHour, onChangeMinute }: { value?: Date
                 }}
                 itemTextStyle={{
                     color: colors.text,
-                    // backgroundColor:colors.neutral
                 }}
                 overlayItemStyle={{
                     backgroundColor: colors.neutral
-                    // marHorizontal: 10
                 }}
             />
         </View>)
 }
 
-export const FormDateTimePickerV2 = ({ control, rules }:
+// 🚨 Ajout de initialDate dans les props du composant
+export const FormDateTimePickerV2 = ({ control, rules, initialDate }:
     {
         control: any;
-        rules: any
+        rules: any;
+        initialDate?: string | Date;
     }) => {
-
-
 
     const { field: { value: startDate, onChange: setStartDate } } = useController({
         control,
@@ -99,7 +93,6 @@ export const FormDateTimePickerV2 = ({ control, rules }:
     const [showEndDateTimePicker, setShowEndDateTimePicker] = useState(false);
     const { formatDate, formatHour } = useI18nTime();
 
-
     return (
         <View className="gap-2">
             <View>
@@ -124,6 +117,9 @@ export const FormDateTimePickerV2 = ({ control, rules }:
                         exiting={StretchOutY}
                     >
                         <Calendar
+                            // ✨ LA MAGIE OPÈRE ICI : Si on a déjà choisi une date, on ouvre le calendrier dessus. 
+                            // Sinon, on s'ouvre sur la date de début du séjour (initialDate).
+                            initialDate={startDate ? String(startDate) : (initialDate ? String(initialDate) : undefined)}
                             enableSwipeMonths
                             theme={{
                                 backgroundColor: colors.calendarBackground,
@@ -289,5 +285,3 @@ export const FormDateTimePickerV2 = ({ control, rules }:
         </View >
     )
 }
-
-


### PR DESCRIPTION
Corection du bug de calendrier qui forçait à scroller. J'en ai profité pour alléger le code avec le TripContact a lieu de la syntaxe spread

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event start/end date defaults now respect link-provided values and no longer overwrite them with trip-based fallbacks; explicitly chosen dates are preserved.
  * The event date-time picker now initializes from the current trip’s start date when available.
  * Event creation and navigation now consistently use the current trip identifier for the correct event context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->